### PR TITLE
Create workflow that generates openapi doc & raises PR when triggered

### DIFF
--- a/.github/workflows/update-openapi-doc.yml
+++ b/.github/workflows/update-openapi-doc.yml
@@ -1,0 +1,60 @@
+name: Update OpenAPI Document
+on:
+  repository_dispatch:
+    types: [jaxrs-files-updated]
+env:
+  TESSERA_DIR: tessera
+  DOC_DIR: doc.tessera
+  DOC_REF: refs/heads/gh-pages
+  DOC_OPENAPI_PATH: tessera_rest_openapi3_spec.latest.yaml
+  TESSERA_REPO: ${{ github.event.client_payload.repo }}
+  TESSERA_REF: ${{ github.event.client_payload.ref }}
+  TESSERA_SHA: ${{ github.event.client_payload.sha }}
+  TESSERA_OPENAPI_PATH: ${{ github.event.client_payload.openapi-path }}
+jobs:
+  run:
+    name: Check for updates and raise PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Checkout docs
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.DOC_REF }}
+          path: ${{ env.DOC_DIR }}
+      - name: Checkout Tesssera
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.TESSERA_REPO }}
+          ref: ${{ env.TESSERA_REF }}
+          token: ${{ secrets.QUORUMBOT_PAT }}
+          path: ${{ env.TESSERA_DIR }}
+      - name: Grant execute permission for gradlew
+        working-directory: ${{ env.TESSERA_DIR }}
+        run: chmod +x gradlew
+      - name: Generate OpenAPI document
+        working-directory: ${{ env.TESSERA_DIR }}
+        run: ./gradlew -Dorg.gradle.jvmargs=-Xmx4096m generateOpenApiDoc
+      - name: Copy OpenAPI document to ${{ env.DOC_DIR }}
+        run: |
+          cp ${{ env.TESSERA_DIR }}/${{ env.TESSERA_OPENAPI_PATH }} ${{ env.DOC_DIR }}/${{ env.DOC_OPENAPI_PATH }}
+      - name: Raise PR if changes
+        id: pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.QUORUMBOT_PAT }}
+          path: ${{ env.DOC_DIR }}
+          commit-message: Automated openapi doc update
+          branch: automated-openapi-update
+          delete-branch: true
+          title: Automated openapi doc update
+          body: Automated update of openapi documentation triggered by repo=${{ env.TESSERA_REPO }} ref=${{ env.TESSERA_REF }} sha=${{ env.TESSERA_SHA }}
+      - name: Summary
+        run: |
+          echo "Triggered by ${{ env.TESSERA_REPO }} ${{ env.TESSERA_REF }} ${{ env.TESSERA_SHA }}"
+          echo "Created PR ${{ steps.pr.outputs.pull-request-url }}"
+
+


### PR DESCRIPTION
Adds event listener that, when triggered, performs Tessera openapi generation and raises a PR against the `gh-pages` branch if there any changes.

The `peter-evans/create-pull-request@v3` action will update the same PR if further changes are made before it is merged.  Once the PR is merged the branch will be deleted automatically.
