### PR TITLE
fix syntax of help command line

### DIFF
--- a/docs/HowTo/Get-started/Build-From-Source.md
+++ b/docs/HowTo/Get-started/Build-From-Source.md
@@ -35,5 +35,5 @@ Build Tessera with the Gradle wrapper `gradlew`, omitting tests as follows:
 Verify the installation with the `help` command:
 
 ```bash
-./tessera-dist/build/install/tessera/bin/tessera/ help
+./tessera-dist/build/install/tessera/bin/tessera help
 ```


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Command line was incorrect. Without this fix:
```
➜  tessera git:(master) ./tessera-dist/build/install/tessera/bin/tessera/ help

zsh: not a directory: ./tessera-dist/build/install/tessera/bin/tessera/
```
With this fix:
```
➜  tessera git:(master) ./tessera-dist/build/install/tessera/bin/tessera help
Tessera - Privacy Manager for Quorum

Usage: tessera [OPTIONS] [COMMAND]

Description: Start a Tessera node.  Subcommands exist to manage Tessera encryption keys

Options:
      -configfile, --configfile, --config-file <config>
...
```
