### PR TITLE
add full cmd line with custom logback file

### DIFF
--- a/docs/HowTo/Use/Logging.md
+++ b/docs/HowTo/Use/Logging.md
@@ -273,4 +273,7 @@ of the root cause is logged as part of the message.
 The level of logging is controlled by the Logback configuration file. The default file packaged with Tessera can be seen [here](https://github.com/ConsenSys/tessera/blob/master/tessera-dist/src/main/resources/logback.xml).
 
 To specify a different logging configuration, pass a customised Logback file on the command line using:
-`-Dlogback.configurationFile=/path/to/logback.xml`
+
+```bash
+JAVA_OPTS="-Dlogback.configurationFile=/path/to/logback.xml" tessera --configfile config.json
+````

--- a/docs/HowTo/Use/Logging.md
+++ b/docs/HowTo/Use/Logging.md
@@ -272,7 +272,7 @@ of the root cause is logged as part of the message.
 
 The level of logging is controlled by the Logback configuration file. The default file packaged with Tessera can be seen [here](https://github.com/ConsenSys/tessera/blob/master/tessera-dist/src/main/resources/logback.xml).
 
-To specify a different logging configuration, pass a customised Logback file on the command line using:
+To specify a different logging configuration, pass a customised Logback file on the command line:
 
 ```bash
 JAVA_OPTS="-Dlogback.configurationFile=/path/to/logback.xml" tessera --configfile config.json


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Feedback from user:

Heya! How does one change the logging level in tessera? I found the documentation here: https://docs.tessera.consensys.net/en/stable/HowTo/Use/Logging/
However, when I call tessera -Dlogback.configurationFile=/path/to/my/logback.xml -configfile tessera.conf I receive the following error: 
2021-12-05 21:37:54.951 [main] WARN  c.q.t.config.cli.TesseraCommand - Using unmatched CLI options for config overrides is deprecated.  Use the --override option instead.

...
 Thanks, I was able to solve the issue via JAVA_OPTS="-Dlogback.configurationFile=/path/to/my/logback.xml" tessera -configfile tessera.conf

