### PR TITLE
add extra cmd line for how to exclude coverage so you can run it locally

### DIFF
--- a/docs/HowTo/Get-started/Build-From-Source.md
+++ b/docs/HowTo/Get-started/Build-From-Source.md
@@ -32,6 +32,12 @@ Build Tessera with the Gradle wrapper `gradlew`, omitting tests as follows:
 ./gradlew build -x test
 ```
 
+If you get errors about code coverage, you can exclude those tasks:
+
+```bash
+./gradlew build -x test -x :cli:spotlessGroovyGradle -x :config:jacocoTestCoverageVerification -x spotlessJava -x jacocoTestCoverageVerification -x spotlessGroovyGradle -x jacocoTestCoverageVerification -x javadoc
+```
+
 Verify the installation with the `help` command:
 
 ```bash


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

`build - x test` gives me lots of errors locally
```
./gradlew build -x test
...
  Rule violated for class com.quorum.tessera.config.util.PasswordFileUpdaterWriter: lines covered ratio is 0.0, but expected minimum is 1.0
  Rule violated for class com.quorum.tessera.config.util.PasswordFileUpdaterWriter: instructions covered ratio is 0.0, but expected minimum is 1.0
...
```
this tells you how to exclude further tasks to be able to build locally