### PR TITLE
remove reference to GoQuorum-compatible privacy in Besu

### DIFF
--- a/docs/HowTo/Configure/Orion-Mode.md
+++ b/docs/HowTo/Configure/Orion-Mode.md
@@ -1,14 +1,12 @@
 ---
-description: Configure Tessera to use the Besu in a non-GoQuorum privacy mode.
+description: Configure Tessera to use Besu.
 ---
 
 # Configure Hyperledger Besu support
 
-Tessera provides out-of-the-box support for [Hyperledger Besu](https://besu.hyperledger.org/en/stable/HowTo/Use-Privacy/Privacy/).
-However, additional configuration is required if you are **not** running
-[Besu in GoQuorum privacy mode](https://besu.hyperledger.org/en/stable/HowTo/Use-Privacy/Use-GoQuorum-compatible-privacy/).
+Tessera provides support for [Hyperledger Besu](https://besu.hyperledger.org/en/stable/HowTo/Use-Privacy/Privacy/).
 
-If GoQuorum privacy mode is not enabled in Besu, set [`mode`](../../Reference/SampleConfiguration.md#mode) in the
+To enable Besu support in Tessera, set [`mode`](../../Reference/SampleConfiguration.md#mode) in the
 Tessera [configuration file](Tessera.md) to `orion`.
 
 !!! example "Orion mode configuration"


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

Make sure that:

- [x] You've read the [contribution guidelines](https://consensys.net/docs/doctools/).
- [x] You've [previewed your changes locally](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-locally).

## Describe the change

Remove reference to GoQuorum-compatible privacy in Besu. Just stick to orion mode.

Fixes https://github.com/ConsenSys/doc.tessera/issues/169

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://consensys.net/docs/doctools/en/latest/preview/old-system/#preview-on-read-the-docs)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://pegasys-tessera--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
